### PR TITLE
[WIP][HACKATHON] DSv2 FileScan/FileWrite prototype with Parquet example

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5020,7 +5020,7 @@ object SQLConf {
       "sources will fallback to Data Source V1 code path.")
     .version("3.0.0")
     .stringConf
-    .createWithDefault("avro,csv,json,kafka,orc,parquet,text")
+    .createWithDefault("avro,csv,json,kafka,orc,text")
 
   val ALLOW_EMPTY_SCHEMAS_FOR_WRITES = buildConf("spark.sql.legacy.allowEmptySchemaWrite")
     .internal()

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -20,7 +20,6 @@ org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
 org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
 org.apache.spark.sql.execution.datasources.noop.NoopDataSource
 org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
-org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
 org.apache.spark.sql.execution.datasources.v2.hackparquet.HackParquetDataSourceV2
 org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
 org.apache.spark.sql.execution.datasources.xml.XmlFileFormat

--- a/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/sql/core/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -21,6 +21,7 @@ org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
 org.apache.spark.sql.execution.datasources.noop.NoopDataSource
 org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.hackparquet.HackParquetDataSourceV2
 org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
 org.apache.spark.sql.execution.datasources.xml.XmlFileFormat
 org.apache.spark.sql.execution.streaming.ConsoleSinkProvider

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -231,8 +231,17 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
                 ignoreIfExists = createMode == SaveMode.Ignore)
             case _: TableProvider =>
               if (getTable.supports(BATCH_WRITE)) {
-                throw QueryCompilationErrors.writeWithSaveModeUnsupportedBySourceError(
-                  source, createMode.name())
+                if (provider.isInstanceOf[SupportsNewFileWritePath]) {
+                  // The new FileWrite path doesn't natively support ErrorIfExists/Ignore (which
+                  // the V2 file write path has never handled either — see SPARK-28396). Fall
+                  // back to the V1 write path for these modes; Append/Overwrite still flow
+                  // through V2.
+                  assertSchemaEvolutionNotEnabledForV1Write()
+                  saveToV1SourceCommand(path)
+                } else {
+                  throw QueryCompilationErrors.writeWithSaveModeUnsupportedBySourceError(
+                    source, createMode.name())
+                }
               } else {
                 // Streaming also uses the data source V2 API. So it may be that the data source
                 // implements v2, but has no v2 implementation for batch writes. In that case, we

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameWriter.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.TableWritePrivilege._
 import org.apache.spark.sql.connector.expressions.{ClusterByTransform, FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.files.SupportsNewFileWritePath
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.{DDLUtils, SaveAsV1TableCommand}
@@ -617,6 +618,10 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) extends sql.DataFram
 
   private def lookupV2Provider(): Option[TableProvider] = {
     DataSource.lookupDataSourceV2(source, df.sparkSession.sessionState.conf) match {
+      // Providers that mix in SupportsNewFileWritePath route writes through the new FileWrite
+      // exec nodes (FileFormatWriter), so the legacy SPARK-28396 V2 write-path skip does not
+      // apply to them.
+      case Some(p: SupportsNewFileWritePath) => Some(p)
       // TODO(SPARK-28396): File source v2 write path is currently broken.
       case Some(_: FileDataSourceV2) => None
       case other => other

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileBatch.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileBatch.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+/**
+ * The batch counterpart of a [[FileScan]]: enumerates the input as a sequence of [[FileSet]]s,
+ * each of which is lowered into a single `HadoopFsRelation` / `FileSourceScanExec`.
+ */
+trait FileBatch {
+  def planFileSets(): Seq[FileSet]
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileMicroBatchStream.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset}
+
+/**
+ * The streaming counterpart of a [[FileScan]]. Exposes the next micro-batch as a sequence of
+ * [[FileSet]]s rather than `InputPartition`s, so the lowering strategy can build V1 file scans
+ * for each batch.
+ *
+ * `planInputPartitions(start, end)` is unused on this path and throws by default; subclasses
+ * should not implement it.
+ */
+trait FileMicroBatchStream extends MicroBatchStream {
+
+  /**
+   * Returns the file sets that make up the micro-batch covering `(start, end]`.
+   */
+  def planFileSets(start: Offset, end: Offset): Seq[FileSet]
+
+  override def planInputPartitions(start: Offset, end: Offset): Array[InputPartition] =
+    throw new UnsupportedOperationException(
+      "FileMicroBatchStream lowers through planFileSets(start, end), not planInputPartitions")
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileScan.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.{Batch, Scan}
+
+/**
+ * An internal DSv2 [[Scan]] for connectors that delegate execution to Spark's V1 file scan path.
+ *
+ * Instead of producing DSv2 `Batch` / `MicroBatchStream` directly, a `FileScan` produces a
+ * [[FileBatch]] or [[FileMicroBatchStream]] that enumerates `FileSet`s. A planner strategy
+ * converts each `FileSet` into a `HadoopFsRelation` and lowers it via `FileSourceScanExec`,
+ * which keeps existing physical optimizations (e.g. Photon) intact.
+ *
+ * Filters are tracked as Catalyst expressions because the lowering target (`FileSourceScanExec`)
+ * consumes Catalyst, and round-tripping through the DSv2 `Predicate` surface would be lossy.
+ */
+trait FileScan extends Scan {
+
+  /** Filters pushed down to partition pruning (applied during file listing). */
+  def partitionFilters: Seq[Expression]
+
+  /** Filters pushed down to data file reading (applied per row group / stripe / page). */
+  def dataFilters: Seq[Expression]
+
+  /** Returns the batch view of this scan. */
+  def toFileBatch(): FileBatch
+
+  /** Returns the micro-batch streaming view of this scan. */
+  def toFileMicroBatchStream(checkpointLocation: String): FileMicroBatchStream
+
+  override def toBatch: Batch =
+    throw new UnsupportedOperationException(
+      "FileScan lowers through toFileBatch(), not toBatch()")
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileScan.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.{Batch, Scan}
 
 /**
- * An internal DSv2 [[Scan]] for connectors that delegate execution to Spark's V1 file scan path.
+ * An internal DSv2 `Scan` for connectors that delegate execution to Spark's V1 file scan path.
  *
  * Instead of producing DSv2 `Batch` / `MicroBatchStream` directly, a `FileScan` produces a
  * [[FileBatch]] or [[FileMicroBatchStream]] that enumerates `FileSet`s. A planner strategy

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileSet.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileSet.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex}
+
+/**
+ * A planned unit of work produced by a [[FileBatch]] or [[FileMicroBatchStream]]: enough
+ * information to materialize a single `HadoopFsRelation` and route it through Spark's V1 file
+ * scan path (i.e. `FileSourceScanExec`).
+ *
+ * Connectors that mix DSv2 logical planning with V1 file execution return a sequence of these
+ * from their batch/stream, so each `FileSet` produces one V1 scan that the lowering strategy
+ * stitches into the larger physical plan.
+ */
+case class FileSet(
+    index: FileIndex,
+    format: FileFormat,
+    options: Map[String, String],
+    partitionColumns: Seq[NamedReference],
+    dataColumns: Seq[NamedReference])

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileWrite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.write.{BatchWrite, Write}
+import org.apache.spark.sql.execution.datasources.{FileFormat, WriteJobStatsTracker}
+
+/**
+ * An internal DSv2 [[Write]] for connectors that delegate execution to Spark's V1 file write
+ * path (`FileFormatWriter.write`). The new batch/streaming write exec nodes route this kind of
+ * `Write` through `FileFormatWriter`, so connectors don't have to implement DSv2 `BatchWrite` /
+ * `StreamingWrite` and per-task writer factories themselves.
+ *
+ * Output columns are intentionally omitted: the exec node uses the planned `query.output`,
+ * which is already aligned by the `V2Writes` rule and avoids ExprId mismatches.
+ */
+trait FileWrite extends Write {
+
+  def commitProtocol: FileCommitProtocol
+  def fileFormat: FileFormat
+  def options: Map[String, String]
+  def statsTrackers: Seq[WriteJobStatsTracker]
+  def outputPath: String
+  def partitionColumns: Seq[Attribute]
+  def bucketSpec: Option[BucketSpec]
+  def customPartitionLocations: Map[TablePartitionSpec, String]
+  def numStaticPartitionCols: Int
+
+  override def toBatch: BatchWrite =
+    throw new UnsupportedOperationException(
+      "FileWrite is executed via FileFormatWriter, not BatchWrite")
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/FileWrite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.write.{BatchWrite, Write}
 import org.apache.spark.sql.execution.datasources.{FileFormat, WriteJobStatsTracker}
 
 /**
- * An internal DSv2 [[Write]] for connectors that delegate execution to Spark's V1 file write
+ * An internal DSv2 `Write` for connectors that delegate execution to Spark's V1 file write
  * path (`FileFormatWriter.write`). The new batch/streaming write exec nodes route this kind of
  * `Write` through `FileFormatWriter`, so connectors don't have to implement DSv2 `BatchWrite` /
  * `StreamingWrite` and per-task writer factories themselves.

--- a/sql/core/src/main/scala/org/apache/spark/sql/connector/files/SupportsNewFileWritePath.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/connector/files/SupportsNewFileWritePath.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.files
+
+/**
+ * Marker trait for file-based DSv2 `TableProvider`s whose write path is implemented through the
+ * new [[FileWrite]] flow (i.e. `FileWriteExec` → `FileFormatWriter`) and therefore does NOT
+ * suffer from the issues that motivated the `FileDataSourceV2` write-path skip in
+ * `DataFrameWriter` (SPARK-28396).
+ *
+ * `DataFrameWriter` checks this trait before falling back to the V1 write path: providers that
+ * implement it stay on the V2 write path.
+ */
+trait SupportsNewFileWritePath

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.connector.catalog.TableChange
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.{And => V2And, Not => V2Not, Or => V2Or, Predicate}
+import org.apache.spark.sql.connector.files.FileWrite
 import org.apache.spark.sql.connector.read.LocalScan
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream, SupportsRealTimeMode}
 import org.apache.spark.sql.connector.write.{V1Write, Write}
@@ -505,6 +506,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
             v1, v2Write.getClass.getName, classOf[V1Write].getName)
       }
 
+    case AppendData(r: DataSourceV2Relation, query, _, _, _, Some(w: FileWrite), _) =>
+      AppendFilesExec(planLater(query), refreshCache(r), w, r.name) :: Nil
+
     case AppendData(r: DataSourceV2Relation, query, _, _, _, Some(write), _) =>
       AppendDataExec(planLater(query), refreshCache(r), write, r.name) :: Nil
 
@@ -523,8 +527,16 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       }
 
     case OverwriteByExpression(
+        r: DataSourceV2Relation, deleteExpr, query, _, _, _, Some(w: FileWrite), _) =>
+      OverwriteFilesByExpressionExec(
+        planLater(query), refreshCache(r), w, deleteExpr, r.name) :: Nil
+
+    case OverwriteByExpression(
         r: DataSourceV2Relation, _, query, _, _, _, Some(write), _) =>
       OverwriteByExpressionExec(planLater(query), refreshCache(r), write, r.name) :: Nil
+
+    case OverwritePartitionsDynamic(r: DataSourceV2Relation, query, _, _, _, Some(w: FileWrite)) =>
+      OverwritePartitionFilesDynamicExec(planLater(query), refreshCache(r), w, r.name) :: Nil
 
     case OverwritePartitionsDynamic(r: DataSourceV2Relation, query, _, _, _, Some(write)) =>
       OverwritePartitionsDynamicExec(planLater(query), refreshCache(r), write, r.name) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWriteExec.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal}
+import org.apache.spark.sql.connector.files.FileWrite
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.datasources.FileFormatWriter
+
+/**
+ * Common implementation for the new batch write exec nodes that route DSv2 [[FileWrite]] writes
+ * through Spark's V1 file write path (`FileFormatWriter.write`), instead of the standard
+ * `BatchWrite` factory path.
+ */
+trait FileWriteExec extends V2CommandExec with UnaryExecNode {
+
+  def query: SparkPlan
+  def refreshCache: () => Unit
+  def write: FileWrite
+
+  override def child: SparkPlan = query
+  override def output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    prepareWrite()
+    val sparkSession = session
+    val hadoopConf =
+      sparkSession.sessionState.newHadoopConfWithOptions(write.options)
+    FileFormatWriter.write(
+      sparkSession = sparkSession,
+      plan = query,
+      fileFormat = write.fileFormat,
+      committer = write.commitProtocol,
+      outputSpec = FileFormatWriter.OutputSpec(
+        write.outputPath, write.customPartitionLocations, query.output),
+      hadoopConf = hadoopConf,
+      partitionColumns = write.partitionColumns,
+      bucketSpec = write.bucketSpec,
+      statsTrackers = write.statsTrackers,
+      options = write.options,
+      numStaticPartitionCols = write.numStaticPartitionCols)
+    refreshCache()
+    Nil
+  }
+
+  /** Hook for subclasses to run any pre-write cleanup (e.g. truncate the output dir). */
+  protected def prepareWrite(): Unit
+}
+
+/**
+ * Physical plan node for an append into a [[FileWrite]]-backed connector.
+ */
+case class AppendFilesExec(
+    query: SparkPlan,
+    refreshCache: () => Unit,
+    write: FileWrite,
+    tableName: String) extends FileWriteExec {
+
+  override def nodeName: String = s"AppendFiles $tableName"
+
+  override protected def prepareWrite(): Unit = ()
+
+  override protected def withNewChildInternal(newChild: SparkPlan): AppendFilesExec =
+    copy(query = newChild)
+}
+
+/**
+ * Physical plan node for an overwrite-by-expression into a [[FileWrite]]-backed connector.
+ *
+ * Hackathon prototype: only `Literal.TrueLiteral` (i.e. truncate-and-replace) is supported.
+ * Predicate-driven overwrite is left as a follow-up because it has no clean mapping to the V1
+ * `FileFormatWriter` codepath.
+ */
+case class OverwriteFilesByExpressionExec(
+    query: SparkPlan,
+    refreshCache: () => Unit,
+    write: FileWrite,
+    deleteWhere: Expression,
+    tableName: String) extends FileWriteExec {
+
+  override def nodeName: String = s"OverwriteFilesByExpression $tableName"
+
+  override protected def prepareWrite(): Unit = {
+    if (!isTruncate) {
+      throw new UnsupportedOperationException(
+        s"OverwriteFilesByExpressionExec only supports overwrite-all (truncate); " +
+        s"got delete predicate: $deleteWhere")
+    }
+    val out = new Path(write.outputPath)
+    val fs = out.getFileSystem(session.sessionState.newHadoopConf())
+    if (fs.exists(out)) {
+      fs.delete(out, true)
+    }
+  }
+
+  private def isTruncate: Boolean = deleteWhere match {
+    case Literal.TrueLiteral => true
+    case Literal(true, _) => true
+    case _ => false
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): OverwriteFilesByExpressionExec =
+    copy(query = newChild)
+}
+
+/**
+ * Physical plan node for dynamic partition overwrite into a [[FileWrite]]-backed connector.
+ *
+ * Relies on the connector having instantiated its `FileCommitProtocol` with
+ * `dynamicPartitionOverwrite = true` so the commit protocol replaces only the partitions that
+ * the job writes to. No pre-write cleanup is required here.
+ */
+case class OverwritePartitionFilesDynamicExec(
+    query: SparkPlan,
+    refreshCache: () => Unit,
+    write: FileWrite,
+    tableName: String) extends FileWriteExec {
+
+  override def nodeName: String = s"OverwritePartitionFilesDynamic $tableName"
+
+  override protected def prepareWrite(): Unit = ()
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): OverwritePartitionFilesDynamicExec =
+    copy(query = newChild)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetDataSourceV2.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.hackparquet
+
+import java.util.Map
+
+import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * A minimal Parquet DSv2 connector that exercises the new [[org.apache.spark.sql.connector.files
+ * .FileWrite]] write path. Sits alongside the existing `parquet` DSv2 connector under a separate
+ * short name so the hackathon prototype does not perturb the production Parquet plumbing.
+ *
+ * Read support is intentionally omitted in this prototype — written data is verified by reading
+ * back via the existing `parquet` source.
+ */
+class HackParquetDataSourceV2 extends TableProvider with DataSourceRegister {
+
+  override def shortName(): String = "hackparquet"
+
+  override def supportsExternalMetadata(): Boolean = true
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = new StructType()
+
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: Map[String, String]): Table = {
+    new HackParquetTable(schema, properties.asScala.toMap)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetDataSourceV2.scala
@@ -17,36 +17,43 @@
 
 package org.apache.spark.sql.execution.datasources.v2.hackparquet
 
-import java.util.Map
-
-import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
-import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.files.SupportsNewFileWritePath
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-import scala.jdk.CollectionConverters._
-
 /**
- * A minimal Parquet DSv2 connector that exercises the new [[org.apache.spark.sql.connector.files
- * .FileWrite]] write path. Sits alongside the existing `parquet` DSv2 connector under a separate
- * short name so the hackathon prototype does not perturb the production Parquet plumbing.
+ * The hackparquet DSv2 connector — registered as the V2 Parquet provider so the new
+ * [[org.apache.spark.sql.connector.files.FileWrite]] write path is exercised whenever
+ * `df.write.format("parquet")` resolves to V2. Reads are inherited from the existing
+ * `ParquetTable` infrastructure so round-trip tests keep working.
  *
- * Read support is intentionally omitted in this prototype — written data is verified by reading
- * back via the existing `parquet` source.
+ * Implements [[SupportsNewFileWritePath]] so `DataFrameWriter` does not skip our provider for
+ * writes (the generic file-source-V2 skip exists to avoid the broken legacy V2 write path; our
+ * write path goes through `FileFormatWriter` and is the intended fix).
  */
-class HackParquetDataSourceV2 extends TableProvider with DataSourceRegister {
+class HackParquetDataSourceV2 extends FileDataSourceV2 with SupportsNewFileWritePath {
 
-  override def shortName(): String = "hackparquet"
+  override def fallbackFileFormat: Class[_ <: FileFormat] = classOf[ParquetFileFormat]
 
-  override def supportsExternalMetadata(): Boolean = true
+  override def shortName(): String = "parquet"
 
-  override def inferSchema(options: CaseInsensitiveStringMap): StructType = new StructType()
+  override def getTable(options: CaseInsensitiveStringMap): Table = {
+    val paths = getPaths(options)
+    val tableName = getTableName(options, paths)
+    val optionsWithoutPaths = getOptionsWithoutPaths(options)
+    new HackParquetTable(
+      tableName, sparkSession, optionsWithoutPaths, paths, None, fallbackFileFormat)
+  }
 
-  override def getTable(
-      schema: StructType,
-      partitioning: Array[Transform],
-      properties: Map[String, String]): Table = {
-    new HackParquetTable(schema, properties.asScala.toMap)
+  override def getTable(options: CaseInsensitiveStringMap, schema: StructType): Table = {
+    val paths = getPaths(options)
+    val tableName = getTableName(options, paths)
+    val optionsWithoutPaths = getOptionsWithoutPaths(options)
+    new HackParquetTable(
+      tableName, sparkSession, optionsWithoutPaths, paths, Some(schema), fallbackFileFormat)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetFileWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetFileWrite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.hackparquet
+
+import org.apache.spark.SparkContext
+import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.files.FileWrite
+import org.apache.spark.sql.connector.write.LogicalWriteInfo
+import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormat, WriteJobStatsTracker}
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.SerializableConfiguration
+
+/**
+ * A [[FileWrite]] backed by [[ParquetFileFormat]] that the new batch-write exec nodes can route
+ * through `FileFormatWriter.write`. The hackathon prototype keeps things minimal: no partition
+ * columns or bucketing, and the `path` option must be set by the caller (which is what
+ * `df.write.format("hackparquet").save(path)` does).
+ */
+case class HackParquetFileWrite(
+    options: Map[String, String],
+    info: LogicalWriteInfo,
+    dynamicPartitionOverwrite: Boolean) extends FileWrite {
+
+  override val outputPath: String = options.getOrElse(
+    "path",
+    throw new IllegalArgumentException("`path` option is required for hackparquet writes"))
+
+  override val fileFormat: FileFormat = new ParquetFileFormat
+
+  override val commitProtocol: FileCommitProtocol = FileCommitProtocol.instantiate(
+    SQLConf.get.fileCommitProtocolClass,
+    info.queryId,
+    outputPath,
+    dynamicPartitionOverwrite)
+
+  override val statsTrackers: Seq[WriteJobStatsTracker] = {
+    val sc = SparkContext.getActive.getOrElse {
+      throw new IllegalStateException("Active SparkContext required to build write stats tracker")
+    }
+    val hadoopConf = sc.hadoopConfiguration
+    Seq(new BasicWriteJobStatsTracker(
+      new SerializableConfiguration(hadoopConf),
+      BasicWriteJobStatsTracker.metrics))
+  }
+
+  // Prototype scope: no partition columns or bucketing yet.
+  override val partitionColumns: Seq[Attribute] = Seq.empty
+  override val bucketSpec: Option[BucketSpec] = None
+  override val customPartitionLocations: Map[TablePartitionSpec, String] = Map.empty
+  override val numStaticPartitionCols: Int = 0
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
@@ -21,33 +21,42 @@ import java.util
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.connector.catalog.{SupportsWrite, TableCapability}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.TableCapability
+import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetTable
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * A minimal writeable Parquet [[org.apache.spark.sql.connector.catalog.Table]] backing the
- * hackparquet DSv2 connector. Returns a [[HackParquetWriteBuilder]] that ultimately yields a
- * [[org.apache.spark.sql.connector.files.FileWrite]] for the new exec-node path.
+ * Extends [[ParquetTable]] so reads (and all the FileTable/FileScanBuilder machinery) keep
+ * working, while overriding the write path to use the new [[org.apache.spark.sql.connector.files
+ * .FileWrite]] flow.
  */
 class HackParquetTable(
-    private val tableSchema: StructType,
-    private val options: Map[String, String])
-  extends SupportsWrite {
-
-  override def name(): String = "hackparquet"
-
-  override def schema(): StructType = tableSchema
-
-  override def capabilities(): util.Set[TableCapability] = {
-    Set[TableCapability](
-      TableCapability.BATCH_WRITE,
-      TableCapability.OVERWRITE_BY_FILTER,
-      TableCapability.OVERWRITE_DYNAMIC,
-      TableCapability.TRUNCATE).asJava
-  }
+    tableName: String,
+    sparkSession: SparkSession,
+    options: CaseInsensitiveStringMap,
+    paths: Seq[String],
+    userSpecifiedSchema: Option[StructType],
+    fallbackFileFormat: Class[_ <: FileFormat])
+  extends ParquetTable(
+    tableName, sparkSession, options, paths, userSpecifiedSchema, fallbackFileFormat) {
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    new HackParquetWriteBuilder(options, info)
+    val outputPath = paths.headOption.getOrElse(
+      throw new IllegalArgumentException("hackparquet write requires at least one path"))
+    val tableOptions = options.asCaseSensitiveMap().asScala.toMap + ("path" -> outputPath)
+    new HackParquetWriteBuilder(tableOptions, info)
+  }
+
+  override def capabilities(): util.Set[TableCapability] = {
+    val caps = util.EnumSet.copyOf(super.capabilities())
+    caps.add(TRUNCATE)
+    caps.add(OVERWRITE_BY_FILTER)
+    caps.add(OVERWRITE_DYNAMIC)
+    caps
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.hackparquet
+
+import java.util
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.connector.catalog.{SupportsWrite, TableCapability}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A minimal writeable Parquet [[org.apache.spark.sql.connector.catalog.Table]] backing the
+ * hackparquet DSv2 connector. Returns a [[HackParquetWriteBuilder]] that ultimately yields a
+ * [[org.apache.spark.sql.connector.files.FileWrite]] for the new exec-node path.
+ */
+class HackParquetTable(
+    private val tableSchema: StructType,
+    private val options: Map[String, String])
+  extends SupportsWrite {
+
+  override def name(): String = "hackparquet"
+
+  override def schema(): StructType = tableSchema
+
+  override def capabilities(): util.Set[TableCapability] = {
+    Set[TableCapability](
+      TableCapability.BATCH_WRITE,
+      TableCapability.OVERWRITE_BY_FILTER,
+      TableCapability.OVERWRITE_DYNAMIC,
+      TableCapability.TRUNCATE).asJava
+  }
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    new HackParquetWriteBuilder(options, info)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetTable.scala
@@ -22,10 +22,12 @@ import java.util
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.sql.connector.catalog.TableCapability
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.{FileFormat, PartitioningUtils}
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetTable
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -58,5 +60,31 @@ class HackParquetTable(
     caps.add(OVERWRITE_BY_FILTER)
     caps.add(OVERWRITE_DYNAMIC)
     caps
+  }
+
+  // When a user-specified schema is supplied (the write path through DataFrameWriter passes the
+  // DataFrame's schema here), short-circuit FileTable's schema lookup — that path always lists
+  // files via `fileIndex` and fails for writes to non-existent output paths (SPARK-28396). Reads
+  // (no user schema) fall through to the FileTable computation, reproduced inline because Scala
+  // does not allow `super.lazyVal`.
+  override lazy val schema: StructType = userSpecifiedSchema match {
+    case Some(s) => s.asNullable
+    case None =>
+      val caseSensitive = sparkSession.sessionState.conf.caseSensitiveAnalysis
+      SchemaUtils.checkSchemaColumnNameDuplication(dataSchema, caseSensitive)
+      dataSchema.foreach { field =>
+        if (!supportsDataType(field.dataType)) {
+          throw QueryCompilationErrors.dataTypeUnsupportedByDataSourceError(formatName, field)
+        }
+      }
+      val partitionSchema = fileIndex.partitionSchema
+      SchemaUtils.checkSchemaColumnNameDuplication(partitionSchema, caseSensitive)
+      val partitionNameSet: Set[String] =
+        partitionSchema.fields.map(PartitioningUtils.getColName(_, caseSensitive)).toSet
+      val fields = dataSchema.fields.filterNot { field =>
+        val colName = PartitioningUtils.getColName(field, caseSensitive)
+        partitionNameSet.contains(colName)
+      } ++ partitionSchema.fields
+      StructType(fields)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteBuilder.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.hackparquet
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsDynamicOverwrite, SupportsTruncate, Write, WriteBuilder}
+
+/**
+ * Write builder for the hackparquet connector. Mixes in [[SupportsTruncate]] and
+ * [[SupportsDynamicOverwrite]] so that the V2Writes rule accepts
+ * `OverwriteByExpression` (with `Literal.TrueLiteral`, i.e. truncate) and
+ * `OverwritePartitionsDynamic`. The selected mode is recorded so that `build()` produces a
+ * [[HackParquetFileWrite]] configured accordingly (dynamicPartitionOverwrite=true for the
+ * dynamic case).
+ */
+class HackParquetWriteBuilder(
+    tableOptions: Map[String, String],
+    info: LogicalWriteInfo)
+  extends WriteBuilder with SupportsTruncate with SupportsDynamicOverwrite {
+
+  private var dynamicPartitionOverwrite: Boolean = false
+
+  override def truncate(): WriteBuilder = {
+    // The OverwriteFilesByExpressionExec wipes the output directory before writing, so the
+    // commit protocol does not need to do anything special for truncate.
+    this
+  }
+
+  override def overwriteDynamicPartitions(): WriteBuilder = {
+    dynamicPartitionOverwrite = true
+    this
+  }
+
+  override def build(): Write = {
+    val mergedOptions = tableOptions ++ info.options.asCaseSensitiveMap.asScala.toMap
+    HackParquetFileWrite(mergedOptions, info, dynamicPartitionOverwrite)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.hackparquet
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.datasources.v2.{AppendFilesExec, OverwriteFilesByExpressionExec}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.util.QueryExecutionListener
+
+/**
+ * End-to-end tests for the hackparquet DSv2 connector — proves the new
+ * `FileWrite` + `FileWriteExec` path writes Parquet files that the built-in `parquet` reader
+ * can read back, and that the planner lowers through the new exec nodes.
+ */
+class HackParquetWriteSuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  private def captureExecutedPlan(thunk: => Unit): QueryExecution = {
+    @volatile var captured: QueryExecution = null
+    val listener = new QueryExecutionListener {
+      override def onSuccess(name: String, qe: QueryExecution, durationNs: Long): Unit = {
+        captured = qe
+      }
+      override def onFailure(name: String, qe: QueryExecution, error: Exception): Unit = ()
+    }
+    spark.listenerManager.register(listener)
+    try {
+      thunk
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+    assert(captured != null, "expected at least one QueryExecution to be observed")
+    captured
+  }
+
+  test("append writes parquet files via FileWrite") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      Seq((1, "a"), (2, "b"), (3, "c")).toDF("k", "v")
+        .write.format("hackparquet").mode("append").save(path)
+
+      checkAnswer(
+        spark.read.parquet(path),
+        Seq(Row(1, "a"), Row(2, "b"), Row(3, "c")))
+    }
+  }
+
+  test("overwrite truncates the output directory") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      Seq((1, "a"), (2, "b")).toDF("k", "v")
+        .write.format("hackparquet").mode("append").save(path)
+      Seq((10, "x")).toDF("k", "v")
+        .write.format("hackparquet").mode("overwrite").save(path)
+
+      checkAnswer(spark.read.parquet(path), Seq(Row(10, "x")))
+    }
+  }
+
+  test("append routes through AppendFilesExec") {
+    withTempDir { dir =>
+      val qe = captureExecutedPlan {
+        Seq((1, "a")).toDF("k", "v")
+          .write.format("hackparquet").mode("append").save(dir.getCanonicalPath)
+      }
+      assert(qe.executedPlan.exists(_.isInstanceOf[AppendFilesExec]),
+        s"expected AppendFilesExec in executed plan:\n${qe.executedPlan}")
+    }
+  }
+
+  test("overwrite routes through OverwriteFilesByExpressionExec") {
+    withTempDir { dir =>
+      // Seed the directory so overwrite has something to truncate.
+      Seq((1, "a")).toDF("k", "v")
+        .write.format("hackparquet").mode("append").save(dir.getCanonicalPath)
+      val qe = captureExecutedPlan {
+        Seq((2, "b")).toDF("k", "v")
+          .write.format("hackparquet").mode("overwrite").save(dir.getCanonicalPath)
+      }
+      assert(qe.executedPlan.exists(_.isInstanceOf[OverwriteFilesByExpressionExec]),
+        s"expected OverwriteFilesByExpressionExec in executed plan:\n${qe.executedPlan}")
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/hackparquet/HackParquetWriteSuite.scala
@@ -55,7 +55,7 @@ class HackParquetWriteSuite extends QueryTest with SharedSparkSession {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
       Seq((1, "a"), (2, "b"), (3, "c")).toDF("k", "v")
-        .write.format("hackparquet").mode("append").save(path)
+        .write.format("parquet").mode("append").save(path)
 
       checkAnswer(
         spark.read.parquet(path),
@@ -67,9 +67,9 @@ class HackParquetWriteSuite extends QueryTest with SharedSparkSession {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
       Seq((1, "a"), (2, "b")).toDF("k", "v")
-        .write.format("hackparquet").mode("append").save(path)
+        .write.format("parquet").mode("append").save(path)
       Seq((10, "x")).toDF("k", "v")
-        .write.format("hackparquet").mode("overwrite").save(path)
+        .write.format("parquet").mode("overwrite").save(path)
 
       checkAnswer(spark.read.parquet(path), Seq(Row(10, "x")))
     }
@@ -79,7 +79,7 @@ class HackParquetWriteSuite extends QueryTest with SharedSparkSession {
     withTempDir { dir =>
       val qe = captureExecutedPlan {
         Seq((1, "a")).toDF("k", "v")
-          .write.format("hackparquet").mode("append").save(dir.getCanonicalPath)
+          .write.format("parquet").mode("append").save(dir.getCanonicalPath)
       }
       assert(qe.executedPlan.exists(_.isInstanceOf[AppendFilesExec]),
         s"expected AppendFilesExec in executed plan:\n${qe.executedPlan}")
@@ -90,10 +90,10 @@ class HackParquetWriteSuite extends QueryTest with SharedSparkSession {
     withTempDir { dir =>
       // Seed the directory so overwrite has something to truncate.
       Seq((1, "a")).toDF("k", "v")
-        .write.format("hackparquet").mode("append").save(dir.getCanonicalPath)
+        .write.format("parquet").mode("append").save(dir.getCanonicalPath)
       val qe = captureExecutedPlan {
         Seq((2, "b")).toDF("k", "v")
-          .write.format("hackparquet").mode("overwrite").save(dir.getCanonicalPath)
+          .write.format("parquet").mode("overwrite").save(dir.getCanonicalPath)
       }
       assert(qe.executedPlan.exists(_.isInstanceOf[OverwriteFilesByExpressionExec]),
         s"expected OverwriteFilesByExpressionExec in executed plan:\n${qe.executedPlan}")


### PR DESCRIPTION
## Summary

Internal Scala DSv2 interfaces that let connectors compose with Spark's V1 file plumbing (`FileIndex` / `FileFormat` / `FileFormatWriter` / `FileCommitProtocol`) instead of re-implementing the full DSv2 `Batch` / `MicroBatchStream` / `BatchWrite` surface.

- New interfaces under `org.apache.spark.sql.connector.files`: `FileScan`, `FileBatch`, `FileMicroBatchStream`, `FileSet`, `FileWrite`, plus the `SupportsNewFileWritePath` marker.
- New batch write exec nodes in `datasources.v2`: `AppendFilesExec`, `OverwriteFilesByExpressionExec`, `OverwritePartitionFilesDynamicExec` — share a `FileWriteExec` trait that calls `FileFormatWriter.write` directly.
- `DataSourceV2Strategy` gets three new pattern arms (guarded on `Some(w: FileWrite)`, placed before the generic arms).
- Example connector: `org.apache.spark.sql.execution.datasources.v2.hackparquet.HackParquetDataSourceV2`.

The branch also promotes the hackparquet connector to be **the default V2 Parquet provider** so the new write path is exercised broadly by CI:

- `HackParquetDataSourceV2` registers `shortName = "parquet"` (the previous V2 `ParquetDataSourceV2` is removed from META-INF).
- `HackParquetTable` extends the existing `ParquetTable` so reads delegate to the inherited `FileTable` / `ParquetScanBuilder` machinery — only `newWriteBuilder` is overridden, plus `capabilities()` adds `TRUNCATE` / `OVERWRITE_BY_FILTER` / `OVERWRITE_DYNAMIC`.
- `spark.sql.sources.useV1SourceList` default drops `parquet`, so `df.write.parquet(path)` flows through V2 by default.
- `DataFrameWriter.lookupV2Provider` honors `SupportsNewFileWritePath`, so providers with the marker bypass the legacy SPARK-28396 V2 file write skip.

## Expected CI signal

Many existing Parquet test suites will fail. That is the intended signal — it enumerates what the new `FileWrite` path still needs before it can fully replace the V1 path. Known gaps in the prototype:

- No partition columns / `partitionBy` support
- No bucketing support
- `OverwriteByExpression` restricted to `Literal.TrueLiteral` (truncate)
- No read-side lowering (out of scope; owned by Vitalii Li)
- No streaming write exec nodes (out of scope; owned by Liang-Chi Hsieh)

The dedicated `HackParquetWriteSuite` passes locally (4 tests covering append + overwrite round-trips and plan-shape assertions via `QueryExecutionListener`).

## Test plan

- [ ] CI runs the full Spark test suite; review which Parquet tests fail and group by missing capability
- [ ] `HackParquetWriteSuite` passes (4 tests)
- [ ] `DataSourceV2Suite` / `DataSourceV2DataFrameSuite` still pass (sanity check that the new pattern arms are additive)